### PR TITLE
Fix language server failing to start on Node.js 22+ (fixes #21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 1.0.4 - 2026-05-01
+
+- Fix language server failing to start on Node.js 22+ with `Cannot find module 'core-js/es6'`. Invoke `dist/cli.js` directly to bypass the deprecated `@babel/polyfill` require in the upstream `bin/graphql.js` wrapper.
+
 # 1.0.3 - 2025-09-30
 
 - Bump extension API, remove windows path workaround. Thanks @kubkon!

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "zed_graphql"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_graphql"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 publish = false
 

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "graphql"
 name = "GraphQL"
-version = "1.0.3"
+version = "1.0.4"
 schema_version = 1
 authors = ["Ivan Buryak <ivan.buryak@gmail.com>"]
 description = "GraphQL extension for Zed"

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1,7 +1,7 @@
 use std::{env, fs};
 use zed_extension_api::{self as zed, settings::LspSettings, Result};
 
-const SERVER_PATH: &str = "node_modules/graphql-language-service-cli/bin/graphql.js";
+const SERVER_PATH: &str = "node_modules/graphql-language-service-cli/dist/cli.js";
 const PACKAGE_NAME: &str = "graphql-language-service-cli";
 
 struct GraphQLExtension;
@@ -84,7 +84,7 @@ impl zed::Extension for GraphQLExtension {
                 "-c".to_string(),
                 config_dir,
             ],
-            env: Default::default(),
+            env: vec![("GRAPHQL_NO_NAME_WARNING".to_string(), "true".to_string())],
         })
     }
 }


### PR DESCRIPTION
## Summary

- Invoke `graphql-language-service-cli`'s `dist/cli.js` directly instead of the `bin/graphql.js` wrapper
- The wrapper unconditionally requires the deprecated `@babel/polyfill`, which transitively requires `core-js/es6` — a path that no longer resolves under Node.js 22+ and hard-fails on Node 24 with `Cannot find module 'core-js/es6'`
- Pass `GRAPHQL_NO_NAME_WARNING=true` through `Command.env` (the only other thing the wrapper did)
- Bump to 1.0.4

Fixes #21.

## Why this works

`bin/graphql.js` is just three lines:
```js
process.env.GRAPHQL_NO_NAME_WARNING = true;
require('@babel/polyfill');
require('../dist/cli');
```

`dist/cli.js` is the actual server entry point; it's pure modern code and doesn't need the polyfill on any supported Node version. Skipping the wrapper sidesteps the broken dependency chain entirely. This works for all currently published versions (3.x and 4.0 canary), since the file layout is stable.

## Test plan

- [x] Install on Node.js 24 and confirm the language server starts (was the failing case in #21)
- [ ] Install on Node.js 20 and confirm no regression
- [x] Verify `config_dir` LSP setting still works
- [x] Verify autocomplete / diagnostics in a `.graphql` file