### PR TITLE
Fix empty symbol picker for GraphQL schema files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 1.0.5 - 2026-06-09
+
+- Fix symbol picker (outline) showing nothing in GraphQL schema files. Capture all type system definitions and extensions instead of selection fields. Thanks @rishitells! #24
+
 # 1.0.4 - 2026-05-01
 
 - Fix language server failing to start on Node.js 22+ with `Cannot find module 'core-js/es6'`. Invoke `dist/cli.js` directly to bypass the deprecated `@babel/polyfill` require in the upstream `bin/graphql.js` wrapper.

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "graphql"
 name = "GraphQL"
-version = "1.0.4"
+version = "1.0.5"
 schema_version = 1
 authors = ["Ivan Buryak <ivan.buryak@gmail.com>"]
 description = "GraphQL extension for Zed"

--- a/languages/graphql/outline.scm
+++ b/languages/graphql/outline.scm
@@ -1,9 +1,69 @@
+; Operations (named only)
 (operation_definition
     (operation_type) @context
     (name) @name) @item
 
+; Fragments
 (fragment_definition
     "fragment" @context
     (fragment_name (name) @name)) @item
 
-(field (name) @name) @item
+; Type system definitions
+(object_type_definition
+    "type" @context
+    (name) @name) @item
+
+(interface_type_definition
+    "interface" @context
+    (name) @name) @item
+
+(enum_type_definition
+    "enum" @context
+    (name) @name) @item
+
+(union_type_definition
+    "union" @context
+    (name) @name) @item
+
+(input_object_type_definition
+    "input" @context
+    (name) @name) @item
+
+(scalar_type_definition
+    "scalar" @context
+    (name) @name) @item
+
+(directive_definition
+    "directive" @context
+    (name) @name) @item
+
+; Type extensions
+(object_type_extension
+    "extend" @context
+    "type" @context
+    (name) @name) @item
+
+(interface_type_extension
+    "extend" @context
+    "interface" @context
+    (name) @name) @item
+
+(enum_type_extension
+    "extend" @context
+    "enum" @context
+    (name) @name) @item
+
+(union_type_extension
+    "extend" @context
+    "union" @context
+    (name) @name) @item
+
+(input_object_type_extension
+    "extend" @context
+    "input" @context
+    (name) @name) @item
+
+(scalar_type_extension
+    "extend" @context
+    "scalar" @context
+    (name) @name) @item


### PR DESCRIPTION
## Problem

The symbol picker (outline panel / `space+s` in Helix mode) shows nothing when opening GraphQL schema/SDL files. `outline.scm` only captured `operation_definition`, `fragment_definition`, and a `(field ...)` selection-field capture — none of which exist in schema files.

The `(field ...)` capture matches **selection** fields inside operations (verified against the grammar's `node-types.json`: `field` has `alias`/`arguments`/`selection_set` children), not type definitions, which use `field_definition`. It was present in the initial commit and never worked for schema files.

## Fix

Replace the selection-field capture with captures for all type system definitions and extensions:

- Definitions: `type`, `interface`, `enum`, `union`, `input`, `scalar`, `directive`
- Extensions: the `extend` variants of each

Operations and fragments are unchanged. Dropping the `(field ...)` capture also removes noise where every selected field appeared as its own top-level outline symbol.

All referenced node types and keyword tokens were verified to exist in the pinned grammar (`tree-sitter-graphql` @ `951bde9`).

Also bumps the extension version `1.0.4` → `1.0.5`.

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)